### PR TITLE
Update CodeCov badge to point to team repo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ title: KonTActs
 ---
 
 [![Java CI](https://github.com/AY2425S1-CS2103T-T11-2/tp/actions/workflows/gradle.yml/badge.svg)](https://github.com/AY2425S1-CS2103T-T11-2/tp/actions/workflows/gradle.yml)
-[![codecov](https://codecov.io/gh/se-edu/addressbook-level3/branch/master/graph/badge.svg)](https://codecov.io/gh/se-edu/addressbook-level3)
+[![codecov](https://codecov.io/gh/AY2425S1-CS2103T-T11-2/tp/graph/badge.svg)](https://codecov.io/github/AY2425S1-CS2103T-T11-2/tp)
 
 ![Ui](images/Ui.png)
 


### PR DESCRIPTION
CodeCov badge was initially pointing to the address book repo. It have been updated to the project team repo.

Closes #46.