### PR TITLE
Add GUI functionality to the telegram field

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -33,7 +33,7 @@ public class AddCommand extends Command {
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
-            + PREFIX_TELEGRAM + "@viswa"
+            + PREFIX_TELEGRAM + "@viswa "
             + PREFIX_TAG + "friends "
             + PREFIX_TAG + "owesMoney";
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -123,7 +123,7 @@ public class ParserUtil {
         requireNonNull(address);
         String trimmedTelegram = address.trim();
         if (!Telegram.isValidTelegram(trimmedTelegram)) {
-            throw new ParseException(Address.MESSAGE_CONSTRAINTS);
+            throw new ParseException(Telegram.MESSAGE_CONSTRAINTS);
         }
         return new Telegram(trimmedTelegram);
     }

--- a/src/main/java/seedu/address/model/person/Telegram.java
+++ b/src/main/java/seedu/address/model/person/Telegram.java
@@ -9,13 +9,14 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Telegram {
 
-    public static final String MESSAGE_CONSTRAINTS = "Telegram can take any values, and it should not be blank";
+    public static final String MESSAGE_CONSTRAINTS = "Telegram must start with a '@' and can only contain "
+            + "alphanumeric characters";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[^\\s].*";
+    public static final String VALIDATION_REGEX = "@[a-zA-Z0-9]+";
 
     public final String value;
 

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -67,7 +67,7 @@ public class PersonCard extends UiPart<Region> {
         } else {
             assignment.setText("No assignment available"); // Optional: for better user feedback
         }
-      
+
         /*
         Adopted from ChatGPT.
          */
@@ -78,7 +78,7 @@ public class PersonCard extends UiPart<Region> {
         } else {
             telegram.setDisable(true); // Disable hyperlink if no Telegram ID
         }
-      
+
         if (person.getGithub() != null) {
             github.setText(person.getGithub().toString());
         } else {

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -3,6 +3,7 @@ package seedu.address.ui;
 import java.util.Comparator;
 
 import javafx.fxml.FXML;
+import javafx.scene.control.Hyperlink;
 import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
@@ -42,6 +43,8 @@ public class PersonCard extends UiPart<Region> {
     private Label assignment;
     @FXML
     private FlowPane tags;
+    @FXML
+    private Hyperlink telegram;
 
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
@@ -61,6 +64,38 @@ public class PersonCard extends UiPart<Region> {
             assignment.setText(person.getAssignment().toString());
         } else {
             assignment.setText("No assignment available"); // Optional: for better user feedback
+        }
+        /*
+        Adopted from ChatGPT.
+         */
+        // Set the telegram hyperlink
+        if (person.getTelegram() != null) {
+            telegram.setText(person.getTelegram().value);
+            telegram.setOnAction(event -> openTelegramLink(person.getTelegram().value));
+        } else {
+            telegram.setDisable(true); // Disable hyperlink if no Telegram ID
+        }
+
+    }
+
+    // Adopted from GPT with the java.awt.Desktop.getDesktop().browse(...)
+    /**
+     * Opens the Telegram link in the default web browser.
+     */
+    private void openTelegramLink(String telegramId) {
+        // This is to remove the '@' when keying into the telegram link
+        char[] charArray = telegramId.toCharArray();
+        StringBuilder sb = new StringBuilder();
+
+        for (int i = 1; i < charArray.length; i++) {
+            sb.append(charArray[i]);
+        }
+
+        try {
+            String url = "https://t.me/" + sb.toString();
+            java.awt.Desktop.getDesktop().browse(new java.net.URI(url));
+        } catch (Exception e) {
+            e.printStackTrace();
         }
     }
 }

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -132,6 +132,17 @@
     -fx-text-fill: #010504;
 }
 
+.hyperlink {
+    -fx-font-family: "Segoe UI"; /* Inherit font-family */
+    -fx-font-size: 13px;        /* Inherit font-size */
+    -fx-text-fill: #E2F1E7;     /* Change to a lighter color for hyperlinks */
+    -fx-underline: true;        /* Ensure hyperlink is underlined */
+}
+
+.hyperlink:hover {
+    -fx-text-fill: #2b4274;     /* Change color on hover */
+}
+
 .stack-pane {
      -fx-background-color: derive(#1d1d1d, 20%);
 }

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -9,6 +9,7 @@
 <?import javafx.scene.layout.Region?>
 <?import javafx.scene.layout.VBox?>
 
+<?import javafx.scene.control.Hyperlink?>
 <HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
   <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
@@ -32,7 +33,13 @@
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
       <Label fx:id="assignment" styleClass="cell_small_label" text="\$assignment" />
-
+    <!--Align to the right -->
+    </VBox>
+    <VBox alignment="CENTER_RIGHT" minHeight="105" GridPane.columnIndex="1">
+      <padding>
+        <Insets top="5" right="15" bottom="5" left="5" />
+      </padding>
+      <Hyperlink fx:id="telegram" styleClass="cell_small_label" />
     </VBox>
   </GridPane>
 </HBox>

--- a/src/test/java/seedu/address/model/person/TelegramTest.java
+++ b/src/test/java/seedu/address/model/person/TelegramTest.java
@@ -24,22 +24,27 @@ public class TelegramTest {
         // null address
         assertThrows(NullPointerException.class, () -> Telegram.isValidTelegram(null));
 
-        // invalid addresses
+        // invalid telegram IDs
         assertFalse(Telegram.isValidTelegram("")); // empty string
         assertFalse(Telegram.isValidTelegram(" ")); // spaces only
+        assertFalse(Telegram.isValidTelegram("-")); // one character
+        assertFalse(Telegram.isValidTelegram("Test")); // the ID does not start with @
+        assertFalse(Telegram.isValidTelegram("@Test!!!")); // contains invalid char '!'
+        assertFalse(Telegram.isValidTelegram("@")); // only contains '@' which is not allowed
 
-        // valid addresses
-        assertTrue(Telegram.isValidTelegram("Blk 456, Den Road, #01-355"));
-        assertTrue(Telegram.isValidTelegram("-")); // one character
-        assertTrue(Telegram.isValidTelegram("Leng Inc; 1234 Market St; San Francisco CA 2349879; USA")); // long address
+
+        // valid telegram IDs
+        assertTrue(Telegram.isValidTelegram("@test"));
+        assertTrue(Telegram.isValidTelegram("@1234"));
+        assertTrue(Telegram.isValidTelegram("@test123"));
     }
 
     @Test
     public void equals() {
-        Telegram telegram = new Telegram("Valid Telegram");
+        Telegram telegram = new Telegram("@ValidTelegram");
 
         // same values -> returns true
-        assertTrue(telegram.equals(new Telegram("Valid Telegram")));
+        assertTrue(telegram.equals(new Telegram("@ValidTelegram")));
 
         // same object -> returns true
         assertTrue(telegram.equals(telegram));
@@ -51,6 +56,6 @@ public class TelegramTest {
         assertFalse(telegram.equals(5.0f));
 
         // different values -> returns false
-        assertFalse(telegram.equals(new Telegram("Other Valid Telegram")));
+        assertFalse(telegram.equals(new Telegram("@OtherValidTelegram")));
     }
 }

--- a/src/test/java/seedu/address/testutil/SampleDataUtilTest.java
+++ b/src/test/java/seedu/address/testutil/SampleDataUtilTest.java
@@ -1,0 +1,28 @@
+package seedu.address.testutil;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.AddressBook;
+import seedu.address.model.person.Person;
+import seedu.address.model.util.SampleDataUtil;
+
+public class SampleDataUtilTest {
+    @Test
+    public void getSamplePersons_validData_personsArray() {
+        // Test that sample persons are correctly created
+        Person[] samplePersons = SampleDataUtil.getSamplePersons();
+        assertNotNull(samplePersons);
+        assertEquals(6, samplePersons.length); // Check the array size
+    }
+
+    @Test
+    public void getSampleAddressBook_validData_addressBook() {
+        // Test that the sample address book contains the expected sample persons
+        AddressBook sampleAddressBook = (AddressBook) SampleDataUtil.getSampleAddressBook();
+        assertNotNull(sampleAddressBook);
+        assertEquals(6, sampleAddressBook.getPersonList().size()); // Check the number of persons
+    }
+}


### PR DESCRIPTION
The user can only key in alphanumeric character and the telegram field must start with '@'. 

Moreover, in the GUI, it will be displayed as a hyperlink and it will automatically lead the user to message the person via telegram in their default browser.

Added test cases to improve coverage as well

Closes #66 