### PR TITLE
Update user guide for github command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -242,3 +242,4 @@ Action     | Format, Examples
 **Filter** | `filter t/[TAG] t/[MORE_TAG]…​`<br> e.g., `filter t/friends t/family`
 **List**   | `list`
 **Help**   | `help`
+**GitHub**   | `github n/NAME`


### PR DESCRIPTION
Add `github` command to the command summary.

Closes #104 