### PR TITLE
Update add command error message

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -120,12 +120,33 @@ Adds a person to KonTActs.
 A person can have any number of tags (including 0)
   </box>
 
+<box type="warning" icon=":fa-solid-circle-exclamation:" light>
+
+<md>**GitHub username restrictions**</md>
+* Length of username must between 1 and 39 characters
+* Can contain only alphanumeric characters and hyphens ('-').
+* Hyphens cannot appear at the start or end, nor consecutively within the username
+
+**Valid examples**
+
+`user123`, `user-name`, `username456`
+
+**Invalid examples**
+
+`very-mega-ultra-super-duper-long-username`, `-username`, `username-`, `user--name`, `username_with_special$chars`
+</box>
+
+
+
+
 <box type="definition" icon=":fa-solid-book:" light>
 
 <md>**Examples:**</md>
 * `add n/John Doe p/98765432 e/johnd@example.com telegram/@john github/swag-john33`
 * `add n/Betsy Crowe t/friend e/betsycrowe@example.com p/1234567 telegram/@Betsy t/criminal github/betsy-29`
 </box>
+
+
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -145,7 +145,7 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a GitHub {@code String username} into an {@code Github}.
+     * Parses a GitHub username into an {@code Github} instance.
      * Leading and trailing whitespaces will be trimmed.
      *
      * @throws ParseException if the given {@code username} is invalid.

--- a/src/main/java/seedu/address/model/person/Github.java
+++ b/src/main/java/seedu/address/model/person/Github.java
@@ -4,13 +4,17 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
 /**
- * Represents a Person's github account in the address book.
+ * Represents a Person's GitHub account in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidGithubUsername(String)}
  */
 public class Github {
     public static final String MESSAGE_CONSTRAINTS =
-            "Github usernames should only contain - and alphanumeric characters";
-    public static final String VALIDATION_REGEX = "^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*$";
+            "GitHub usernames can contain only alphanumeric characters and hyphens ('-').\n"
+                    + "Hyphens cannot appear at the start or end, nor consecutively within the username.\n"
+                    + "Length of GitHub usernames must be 1 and 39.\n"
+                    + "Refer to the user guide for more information.";
+
+    public static final String VALIDATION_REGEX = "^(?=.{1,39}$)[a-zA-Z0-9]+(-[a-zA-Z0-9]+)*$";
     public final String username;
 
     /**

--- a/src/test/java/seedu/address/model/person/GithubTest.java
+++ b/src/test/java/seedu/address/model/person/GithubTest.java
@@ -30,13 +30,13 @@ public class GithubTest {
 
         // invalid username
         assertFalse(Github.isValidGithubUsername("")); // empty string
-        assertFalse(Github.isValidGithubUsername(" ")); // spaces only
+        assertFalse(Github.isValidGithubUsername(" ")); // whitespace only
         assertFalse(Github.isValidGithubUsername("-John")); // Starts with hypen only
         assertFalse(Github.isValidGithubUsername("John-")); // Ends with hypen only
         assertFalse(Github.isValidGithubUsername("-John-Doe")); // Starts with hypen and hyphen in between
         assertFalse(Github.isValidGithubUsername("John--Doe")); //  consecutive hypens only
         assertFalse(Github.isValidGithubUsername("-")); // hypen only
-        // long username (>39 characters)
+        // invalid long username (>39 characters)
         assertFalse(Github.isValidGithubUsername("JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ-beepo"));
         assertFalse(Github.isValidGithubUsername("@")); // special character only
         assertFalse(Github.isValidGithubUsername("John Doe")); // whitespace between name
@@ -44,7 +44,7 @@ public class GithubTest {
         // valid username
         assertTrue(Github.isValidGithubUsername("John-Doe"));
         assertTrue(Github.isValidGithubUsername("J")); // one character
-        assertTrue(Github.isValidGithubUsername("JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ-beep")); // long username
+        assertTrue(Github.isValidGithubUsername("JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ-beep")); // 39 characters
     }
 
     @Test


### PR DESCRIPTION
Previously, the add command error message for an invalid GitHub username lacked crucial details. It now contains more information.

Closes #193 