### PR TITLE
Change command prefix to have a alternate form

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -59,7 +59,7 @@ public class ArgumentMultimap {
      * Returns the preamble (text before the first valid prefix). Trims any leading/trailing spaces.
      */
     public String getPreamble() {
-        return getValue(new Prefix("")).orElse("");
+        return getValue(new Prefix("", "")).orElse("");
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -49,9 +49,20 @@ public class ArgumentTokenizer {
 
         int prefixPosition = findPrefixPosition(argsString, prefix.getPrefix(), 0);
         while (prefixPosition != -1) {
-            PrefixPosition extendedPrefix = new PrefixPosition(prefix, prefixPosition);
+            PrefixPosition extendedPrefix = new PrefixPosition(prefix, prefixPosition, false);
             positions.add(extendedPrefix);
             prefixPosition = findPrefixPosition(argsString, prefix.getPrefix(), prefixPosition);
+        }
+
+        if (prefix.getShortPrefix().trim().isEmpty()) {
+            return positions;
+        }
+
+        prefixPosition = findPrefixPosition(argsString, prefix.getShortPrefix(), 0);
+        while (prefixPosition != -1) {
+            PrefixPosition extendedPrefix = new PrefixPosition(prefix, prefixPosition, true);
+            positions.add(extendedPrefix);
+            prefixPosition = findPrefixPosition(argsString, prefix.getShortPrefix(), prefixPosition);
         }
 
         return positions;
@@ -90,11 +101,11 @@ public class ArgumentTokenizer {
         prefixPositions.sort((prefix1, prefix2) -> prefix1.getStartPosition() - prefix2.getStartPosition());
 
         // Insert a PrefixPosition to represent the preamble
-        PrefixPosition preambleMarker = new PrefixPosition(new Prefix(""), 0);
+        PrefixPosition preambleMarker = new PrefixPosition(new Prefix("", ""), 0, false);
         prefixPositions.add(0, preambleMarker);
 
         // Add a dummy PrefixPosition to represent the end of the string
-        PrefixPosition endPositionMarker = new PrefixPosition(new Prefix(""), argsString.length());
+        PrefixPosition endPositionMarker = new PrefixPosition(new Prefix("", ""), argsString.length(), false);
         prefixPositions.add(endPositionMarker);
 
         // Map prefixes to their argument values (if any)
@@ -118,7 +129,11 @@ public class ArgumentTokenizer {
                                         PrefixPosition nextPrefixPosition) {
         Prefix prefix = currentPrefixPosition.getPrefix();
 
-        int valueStartPos = currentPrefixPosition.getStartPosition() + prefix.getPrefix().length();
+        int prefixLength = currentPrefixPosition.isShortForm()
+                ? prefix.getShortPrefix().length()
+                : prefix.getPrefix().length();
+
+        int valueStartPos = currentPrefixPosition.getStartPosition() + prefixLength;
         String value = argsString.substring(valueStartPos, nextPrefixPosition.getStartPosition());
 
         return value.trim();
@@ -131,9 +146,12 @@ public class ArgumentTokenizer {
         private int startPosition;
         private final Prefix prefix;
 
-        PrefixPosition(Prefix prefix, int startPosition) {
+        private boolean isShortForm;
+
+        PrefixPosition(Prefix prefix, int startPosition, boolean isShortForm) {
             this.prefix = prefix;
             this.startPosition = startPosition;
+            this.isShortForm = isShortForm;
         }
 
         int getStartPosition() {
@@ -142,6 +160,10 @@ public class ArgumentTokenizer {
 
         Prefix getPrefix() {
             return prefix;
+        }
+
+        public boolean isShortForm() {
+            return isShortForm;
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentTokenizer.java
@@ -81,7 +81,7 @@ public class ArgumentTokenizer {
      * {@code fromIndex} = 0, this method returns 5.
      */
     private static int findPrefixPosition(String argsString, String prefix, int fromIndex) {
-        int prefixIndex = argsString.indexOf(" " + prefix, fromIndex);
+        int prefixIndex = argsString.toLowerCase().indexOf(" " + prefix, fromIndex);
         return prefixIndex == -1 ? -1
                 : prefixIndex + 1; // +1 as offset for whitespace
     }

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -6,7 +6,7 @@ package seedu.address.logic.parser;
 public class CliSyntax {
 
     /* Prefix definitions */
-    public static final Prefix PREFIX_NAME = new Prefix("name/","n/");
+    public static final Prefix PREFIX_NAME = new Prefix("name/", "n/");
     public static final Prefix PREFIX_EMAIL = new Prefix("email/", "e/");
     public static final Prefix PREFIX_TAG = new Prefix("tag/", "t/");
     public static final Prefix PREFIX_ASSIGNMENT = new Prefix("assignment/", "asgn/");

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -6,14 +6,14 @@ package seedu.address.logic.parser;
 public class CliSyntax {
 
     /* Prefix definitions */
-    public static final Prefix PREFIX_NAME = new Prefix("n/");
-    public static final Prefix PREFIX_EMAIL = new Prefix("e/");
-    public static final Prefix PREFIX_TAG = new Prefix("t/");
-    public static final Prefix PREFIX_ASSIGNMENT = new Prefix("asgn/");
-    public static final Prefix PREFIX_SCORE = new Prefix("s/");
-    public static final Prefix PREFIX_TELEGRAM = new Prefix("telegram/");
-    public static final Prefix PREFIX_GITHUB = new Prefix("github/");
-    public static final Prefix PREFIX_WEEK = new Prefix("w/");
-    public static final Prefix PREFIX_SORTORDER = new Prefix("order/");
-    public static final Prefix PREFIX_PATH = new Prefix("path/");
+    public static final Prefix PREFIX_NAME = new Prefix("name/","n/");
+    public static final Prefix PREFIX_EMAIL = new Prefix("email/", "e/");
+    public static final Prefix PREFIX_TAG = new Prefix("tag/", "t/");
+    public static final Prefix PREFIX_ASSIGNMENT = new Prefix("assignment/", "asgn/");
+    public static final Prefix PREFIX_SCORE = new Prefix("score/", "sc/");
+    public static final Prefix PREFIX_TELEGRAM = new Prefix("telegram/", "tele/");
+    public static final Prefix PREFIX_GITHUB = new Prefix("github/", "g/");
+    public static final Prefix PREFIX_WEEK = new Prefix("week/", "w/");
+    public static final Prefix PREFIX_SORTORDER = new Prefix("order/", "o/");
+    public static final Prefix PREFIX_PATH = new Prefix("path/", "p/");
 }

--- a/src/main/java/seedu/address/logic/parser/Prefix.java
+++ b/src/main/java/seedu/address/logic/parser/Prefix.java
@@ -10,6 +10,9 @@ public class Prefix {
     private final String prefix;
     private final String shortPrefix;
 
+    /**
+     * Creates a {@code Prefix} object with prefix and shortPrefix specified by the arguments.
+     */
     public Prefix(String prefix, String shortPrefix) {
         requireNonNull(prefix, shortPrefix);
         this.prefix = prefix;

--- a/src/main/java/seedu/address/logic/parser/Prefix.java
+++ b/src/main/java/seedu/address/logic/parser/Prefix.java
@@ -1,18 +1,27 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * A prefix that marks the beginning of an argument in an arguments string.
  * E.g. 't/' in 'add James t/ friend'.
  */
 public class Prefix {
     private final String prefix;
+    private final String shortPrefix;
 
-    public Prefix(String prefix) {
+    public Prefix(String prefix, String shortPrefix) {
+        requireNonNull(prefix, shortPrefix);
         this.prefix = prefix;
+        this.shortPrefix = shortPrefix;
     }
 
     public String getPrefix() {
         return prefix;
+    }
+
+    public String getShortPrefix() {
+        return shortPrefix;
     }
 
     @Override
@@ -37,6 +46,6 @@ public class Prefix {
         }
 
         Prefix otherPrefix = (Prefix) other;
-        return prefix.equals(otherPrefix.prefix);
+        return prefix.equals(otherPrefix.prefix) && shortPrefix.equals(otherPrefix.shortPrefix);
     }
 }

--- a/src/test/data/testExport.csv
+++ b/src/test/data/testExport.csv
@@ -1,4 +1,4 @@
-"Name","Phone","Email","Telegram","Tags","Github","Assignments","WeeksPresent"
+"Name","Email","Telegram","Tags","Github","Assignments","WeeksPresent"
 "Alice Pauline","alice@example.com","@Alice","[friends]","Alice","Ex02 | 9.0,ex01 | 0.0",""
 "Benson Meier","johnd@example.com","@Benson","[owesMoney],[friends]","Benson","ex01 | 0.0","1"
 "Carl Kurz","heinz@example.com","@Carl","","Carl","ex01 | 0.0",""

--- a/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
@@ -9,10 +9,11 @@ import org.junit.jupiter.api.Test;
 
 public class ArgumentTokenizerTest {
 
-    private final Prefix unknownPrefix = new Prefix("--u");
-    private final Prefix pSlash = new Prefix("p/");
-    private final Prefix dashT = new Prefix("-t");
-    private final Prefix hatQ = new Prefix("^Q");
+    private final Prefix unknownPrefix = new Prefix("--u", "");
+    private final Prefix pSlash = new Prefix("p/", "");
+    private final Prefix dashT = new Prefix("-t", "");
+    private final Prefix hatQ = new Prefix("^Q", "");
+    private final Prefix tSlashKHat = new Prefix("t/", "K^");
 
     @Test
     public void tokenize_emptyArgsString_noValues() {
@@ -77,25 +78,40 @@ public class ArgumentTokenizerTest {
         assertPreambleEmpty(argMultimap);
         assertArgumentPresent(argMultimap, pSlash, "Argument value");
 
+        // Test short form
+
+        // Preamble present
+        argsString = "  Some preamble string K^ Argument value ";
+        argMultimap = ArgumentTokenizer.tokenize(argsString, tSlashKHat);
+        assertPreamblePresent(argMultimap, "Some preamble string");
+        assertArgumentPresent(argMultimap, tSlashKHat, "Argument value");
+
+        // No preamble
+        argsString = " K^   Argument value ";
+        argMultimap = ArgumentTokenizer.tokenize(argsString, tSlashKHat);
+        assertPreambleEmpty(argMultimap);
+        assertArgumentPresent(argMultimap, tSlashKHat, "Argument value");
     }
 
     @Test
     public void tokenize_multipleArguments() {
-        // Only two arguments are present
-        String argsString = "SomePreambleString -t dashT-Value p/pSlash value";
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
+        // Only three arguments are present
+        String argsString = "SomePreambleString -t dashT-Value p/pSlash value t/tSlashKHat value";
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ, tSlashKHat);
         assertPreamblePresent(argMultimap, "SomePreambleString");
         assertArgumentPresent(argMultimap, pSlash, "pSlash value");
         assertArgumentPresent(argMultimap, dashT, "dashT-Value");
+        assertArgumentPresent(argMultimap, tSlashKHat, "tSlashKHat value");
         assertArgumentAbsent(argMultimap, hatQ);
 
         // All three arguments are present
-        argsString = "Different Preamble String ^Q111 -t dashT-Value p/pSlash value";
-        argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
+        argsString = "Different Preamble String ^Q111 -t dashT-Value p/pSlash value K^tSlashKHat value";
+        argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ, tSlashKHat);
         assertPreamblePresent(argMultimap, "Different Preamble String");
         assertArgumentPresent(argMultimap, pSlash, "pSlash value");
         assertArgumentPresent(argMultimap, dashT, "dashT-Value");
         assertArgumentPresent(argMultimap, hatQ, "111");
+        assertArgumentPresent(argMultimap, tSlashKHat, "tSlashKHat value");
 
         /* Also covers: Reusing of the tokenizer multiple times */
 
@@ -118,12 +134,15 @@ public class ArgumentTokenizerTest {
     @Test
     public void tokenize_multipleArgumentsWithRepeats() {
         // Two arguments repeated, some have empty values
-        String argsString = "SomePreambleString -t dashT-Value ^Q ^Q -t another dashT value p/ pSlash value -t";
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ);
+        String argsString = "SomePreambleString t/ K^ -t dashT-Value ^Q ^Q K^ tSlashKHat value -t another dashT value "
+                + "p/ pSlash value -t t/another tSlashKHat value";
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(argsString, pSlash, dashT, hatQ, tSlashKHat);
         assertPreamblePresent(argMultimap, "SomePreambleString");
         assertArgumentPresent(argMultimap, pSlash, "pSlash value");
         assertArgumentPresent(argMultimap, dashT, "dashT-Value", "another dashT value", "");
         assertArgumentPresent(argMultimap, hatQ, "", "");
+        assertArgumentPresent(argMultimap, tSlashKHat, "", "", "tSlashKHat value",
+                "another tSlashKHat value");
     }
 
     @Test
@@ -138,13 +157,14 @@ public class ArgumentTokenizerTest {
 
     @Test
     public void equalsMethod() {
-        Prefix aaa = new Prefix("aaa");
+        Prefix aaa = new Prefix("aaa", "abc");
 
         assertEquals(aaa, aaa);
-        assertEquals(aaa, new Prefix("aaa"));
+        assertEquals(aaa, new Prefix("aaa", "abc"));
 
         assertNotEquals(aaa, "aaa");
-        assertNotEquals(aaa, new Prefix("aab"));
+        assertNotEquals(aaa, new Prefix("aab", "abc"));
+        assertNotEquals(aaa, new Prefix("aaa", "aab"));
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
+++ b/src/test/java/seedu/address/logic/parser/ArgumentTokenizerTest.java
@@ -12,8 +12,8 @@ public class ArgumentTokenizerTest {
     private final Prefix unknownPrefix = new Prefix("--u", "");
     private final Prefix pSlash = new Prefix("p/", "");
     private final Prefix dashT = new Prefix("-t", "");
-    private final Prefix hatQ = new Prefix("^Q", "");
-    private final Prefix tSlashKHat = new Prefix("t/", "K^");
+    private final Prefix hatQ = new Prefix("^q", "");
+    private final Prefix tSlashKHat = new Prefix("t/", "k^");
 
     @Test
     public void tokenize_emptyArgsString_noValues() {


### PR DESCRIPTION
All prefixses can now be identified in 2 different way, their orginal form and a short form.
Closes #228 
current prefixses and their sort form can be seen here:
![image](https://github.com/user-attachments/assets/d670d253-4d3d-4bcf-a336-187058299e15)
